### PR TITLE
add kosmickrisp to osx-64

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '12'
+- '13'
 MACOSX_SDK_VERSION:
-- '12'
+- '13'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '12'
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '13'
+- '15'
 MACOSX_SDK_VERSION:
-- '13'
+- '15'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '13'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -27,7 +27,7 @@ jobs:
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
-            docker_run_args:
+            docker_run_args: 
             free_disk_space: skip
             os: ubuntu
             pagefile_size: 0
@@ -39,7 +39,7 @@ jobs:
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
-            docker_run_args:
+            docker_run_args: 
             free_disk_space: skip
             os: ubuntu
             pagefile_size: 0
@@ -51,7 +51,7 @@ jobs:
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
-            docker_run_args:
+            docker_run_args: 
             free_disk_space: skip
             os: ubuntu
             pagefile_size: 0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About mesa-lavapipe-feedstock
-=============================
+About mesa-kosmickrisp-feedstock
+================================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/mesalib-feedstock/blob/main/LICENSE.txt)
 
@@ -76,10 +76,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-mesa--llvmpipe-green.svg)](https://anaconda.org/conda-forge/mesa-llvmpipe) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/mesa-llvmpipe.svg)](https://anaconda.org/conda-forge/mesa-llvmpipe) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/mesa-llvmpipe.svg)](https://anaconda.org/conda-forge/mesa-llvmpipe) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/mesa-llvmpipe.svg)](https://anaconda.org/conda-forge/mesa-llvmpipe) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-mesalib-green.svg)](https://anaconda.org/conda-forge/mesalib) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/mesalib.svg)](https://anaconda.org/conda-forge/mesalib) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/mesalib.svg)](https://anaconda.org/conda-forge/mesalib) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/mesalib.svg)](https://anaconda.org/conda-forge/mesalib) |
 
-Installing mesa-lavapipe
-========================
+Installing mesa-kosmickrisp
+===========================
 
-Installing `mesa-lavapipe` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `mesa-kosmickrisp` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -165,17 +165,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating mesa-lavapipe-feedstock
-================================
+Updating mesa-kosmickrisp-feedstock
+===================================
 
-If you would like to improve the mesa-lavapipe recipe or build a new
+If you would like to improve the mesa-kosmickrisp recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/mesa-lavapipe-feedstock are
+Note that all branches in the conda-forge/mesa-kosmickrisp-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,7 +17,7 @@ source:
         - patches/0002-nir-mark-assert-only-variable.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - package:
@@ -98,7 +98,7 @@ outputs:
       version: ${{ version }}
     build:
       skip:
-        - not (osx and arm64)
+        - not osx
       script: build_kosmickrisp
     requirements:
       build:
@@ -128,7 +128,12 @@ outputs:
         - ${{ pin_subpackage('mesa-kosmickrisp', upper_bound='x.x') }}
     tests:
       - script:
-          - test -f $PREFIX/share/vulkan/icd.d/kosmickrisp_mesa_icd.aarch64.json
+          - if: x86_64
+            then:
+              - test -f $PREFIX/share/vulkan/icd.d/kosmickrisp_mesa_icd.x86_64.json
+          - if: arm64
+            then:
+              - test -f $PREFIX/share/vulkan/icd.d/kosmickrisp_mesa_icd.aarch64.json
 
   - package:
       name: mesa-llvmpipe
@@ -210,7 +215,7 @@ outputs:
         - if: not osx
           then:
             - ${{ pin_subpackage('mesa-llvmpipe', exact=True) }}
-        - if: osx and arm64
+        - if: osx
           then:
             - ${{ pin_subpackage('mesa-kosmickrisp', exact=True) }}
       run_exports:
@@ -233,6 +238,9 @@ outputs:
             then:
               - test -f $PREFIX/lib/libEGL_mesa${SHLIB_EXT}
               - test -f $PREFIX/lib/libgallium-*${SHLIB_EXT}
+          - if: osx and x86_64
+            then:
+              - test -f $PREFIX/share/vulkan/icd.d/kosmickrisp_mesa_icd.x86_64.json
           - if: osx and arm64
             then:
               - test -f $PREFIX/share/vulkan/icd.d/kosmickrisp_mesa_icd.aarch64.json

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -15,10 +15,10 @@ c_stdlib_version:
   - if: osx and arm64
     then: '15'
   - if: osx and x86_64
-    then: '13'
+    then: '15'
 
 MACOSX_SDK_VERSION:
   - if: osx and arm64
     then: '15'
   - if: osx and x86_64
-    then: '13'
+    then: '15'

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -15,10 +15,10 @@ c_stdlib_version:
   - if: osx and arm64
     then: '15'
   - if: osx and x86_64
-    then: '12'
+    then: '13'
 
 MACOSX_SDK_VERSION:
   - if: osx and arm64
     then: '15'
   - if: osx and x86_64
-    then: '12'
+    then: '13'


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

26.1 is the last release where KosmicKrisp will be available to intel macs. So we can release it here and remove it in 26.2