### PR TITLE
Windows: stop forcing software OpenGL via Library\bin\opengl32.dll

### DIFF
--- a/recipe/build_llvmpipe.bat
+++ b/recipe/build_llvmpipe.bat
@@ -37,3 +37,26 @@ if %ERRORLEVEL% neq 0 exit 1
 @REM I'm not sure why something is looking for this lib file
 @REM Removed so it doesn't get included as part of the final package
 del %LIBRARY_PREFIX%\lib\zstd.dll.lib
+
+@REM opengl32.dll is a *drop-in replacement* for the system's opengl32.dll --
+@REM see docs/drivers/llvmpipe.rst, "put both DLLs in the same directory as
+@REM your application".  Library\bin is the application directory for every
+@REM conda-installed .exe, and conda-forge's python calls AddDllDirectory() on
+@REM it, and user DLL directories are searched *before* System32.  So leaving
+@REM opengl32.dll there hijacks the vendor's OpenGL driver for the whole
+@REM environment and silently forces software rendering.
+@REM https://github.com/conda-forge/mesalib-feedstock/issues/142
+@REM
+@REM Park it (and its import library, which would otherwise shadow the Windows
+@REM SDK's opengl32.lib at link time) somewhere that is on no DLL search path.
+@REM It is still shipped, so software rendering stays available to anyone who
+@REM wants it: copy opengl32.dll next to your .exe, which is the usage mesa
+@REM itself documents, or add this directory to the DLL search path for a
+@REM single process (os.add_dll_directory() from Python, since user DLL
+@REM directories are searched ahead of System32).
+if not exist %LIBRARY_PREFIX%\opengl32 mkdir %LIBRARY_PREFIX%\opengl32
+if %ERRORLEVEL% neq 0 exit 1
+move /y %LIBRARY_PREFIX%\bin\opengl32.dll %LIBRARY_PREFIX%\opengl32\opengl32.dll
+if %ERRORLEVEL% neq 0 exit 1
+move /y %LIBRARY_PREFIX%\lib\opengl32.lib %LIBRARY_PREFIX%\opengl32\opengl32.lib
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,7 +17,7 @@ source:
         - patches/0002-nir-mark-assert-only-variable.patch
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - package:
@@ -203,8 +203,14 @@ outputs:
               - test -f $PREFIX/lib/libgallium-*${SHLIB_EXT}
           - if: win
             then:
-              - if not exist %LIBRARY_PREFIX%\bin\opengl32.dll exit 1
               - if not exist %LIBRARY_PREFIX%\bin\libgallium_wgl.dll exit 1
+              # opengl32.dll is shipped, but kept off every DLL search path so
+              # it can only be used deliberately.
+              # https://github.com/conda-forge/mesalib-feedstock/issues/142
+              - if not exist %LIBRARY_PREFIX%\opengl32\opengl32.dll exit 1
+              - if not exist %LIBRARY_PREFIX%\opengl32\opengl32.lib exit 1
+              - if exist %LIBRARY_PREFIX%\bin\opengl32.dll exit 1
+              - if exist %LIBRARY_PREFIX%\lib\opengl32.lib exit 1
 
   - package:
       name: mesalib
@@ -248,8 +254,10 @@ outputs:
             then:
               - if not exist %LIBRARY_PREFIX%\bin\vulkan_lvp.dll exit 1
               - if not exist %LIBRARY_PREFIX%\share\vulkan\icd.d\lvp_icd.x86_64.json exit 1
-              - if not exist %LIBRARY_PREFIX%\bin\opengl32.dll exit 1
               - if not exist %LIBRARY_PREFIX%\bin\libgallium_wgl.dll exit 1
+              # Depending on mesalib must never force software OpenGL.
+              # https://github.com/conda-forge/mesalib-feedstock/issues/142
+              - if exist %LIBRARY_PREFIX%\bin\opengl32.dll exit 1
 
 about:
   homepage: https://www.mesa3d.org


### PR DESCRIPTION
Closes #142.

### The problem

`mesa-llvmpipe` ships `Library\bin\opengl32.dll`. Mesa documents that file (`docs/drivers/llvmpipe.rst`) as a drop-in replacement for the **system** `opengl32.dll`, to be dropped next to one specific application. In a conda environment, `Library\bin` is:

1. the *application directory* for every conda-installed `.exe`, which precedes `System32` in every Windows DLL search order, and
2. registered via `AddDllDirectory()` by conda-forge's python (`python-feedstock`'s `0007-Add-CondaEcosystemModifyDllSearchPath.patch`), and user DLL directories are searched **ahead of** `System32`.

So the file hijacked the vendor's OpenGL driver for the entire environment and silently forced software rendering — including for anyone who only pulled `mesalib` in transitively (`viskores` → `vtk-base` → `pcl`, per the tree in the issue). `Library\lib\opengl32.lib` shadowed the Windows SDK import library at link time in the same way.

**Linux is not affected and is not touched by this PR.** We build with `-Dglvnd=enabled`, so mesa installs as a libglvnd vendor and the hardware driver still wins. There is no libglvnd on Windows; `opengl32.dll` is all-or-nothing.

This is not a regression from the multi-output split — `mesalib` has shipped `Library/bin/opengl32.dll` since at least 25.1, which is also why I'd suggest **not** marking anything broken.

### The fix

Software rendering stays available, it just stops being the default. `opengl32.dll` and `opengl32.lib` move to `%LIBRARY_PREFIX%\opengl32`, a directory on no DLL search path, so using them has to be deliberate:

- copy `opengl32.dll` next to your `.exe` — the usage mesa itself documents, or
- register the directory for a single process, e.g. from Python:
  ```python
  import os, sys
  os.add_dll_directory(os.path.join(sys.prefix, "Library", "opengl32"))
  ```
  User DLL directories are searched ahead of `System32`, so mesa wins for that process only.

There is no meson option to skip the `libgl-gdi` target (`src/gallium/meson.build` builds it unconditionally for `platforms=windows` + `opengl=true`), so it is a post-install move. `libgallium_wgl.dll` stays in `Library\bin` — nothing loads it by that name, and it stays reachable via `PATH`.

The `mesa-llvmpipe` and `mesalib` Windows tests now assert `Library\bin\opengl32.dll` is *absent*, so this cannot silently regress.

Verified with `rattler-build --render-only` against each `.ci_support` config: same three outputs per platform as before, at build 3.

### Note for downstreams

Headless Windows CI that relied on the old behaviour will now get Microsoft's GL 1.1 and fail *loudly* rather than run slowly. This probably deserves an announcement.

### Possible follow-ups (not in this PR)

- Building `-Dgallium-drivers=llvmpipe,d3d12,zink` would make mesa's `opengl32.dll` prefer GL-on-D3D12 over llvmpipe (`src/gallium/targets/wgl/wgl.c` driver list), with `LIBGL_ALWAYS_SOFTWARE=1` still forcing software. DirectX-Headers is already pulled into the build. Kept separate because it changes the "guaranteed software" property CI depends on.
- If the manual opt-in above proves too awkward, a small opt-in output that copies the DLL back into `Library\bin` would be easy to add later.
- `viskores` has an unconditional `mesalib` in `host`, and `mesalib` has a `run_exports`, which is how this reaches `pcl` at runtime.
- `mesa-lavapipe` on win-64 ships vendored DirectX-Headers into `Library/include` and `Library/lib` — unrelated packaging leak.
